### PR TITLE
Properly handle potential null mimic state in BlockColors.

### DIFF
--- a/src/main/java/mod/pianomanu/blockcarpentry/util/BlockColorHandler.java
+++ b/src/main/java/mod/pianomanu/blockcarpentry/util/BlockColorHandler.java
@@ -45,7 +45,7 @@ public class BlockColorHandler implements IBlockColor {
             TileEntity te = lightReader.getTileEntity(pos);
             if (te instanceof FrameBlockTile) {
                 BlockState containedBlock = ((FrameBlockTile) te).getMimic();
-                if (containedBlock.getBlock() instanceof GrassBlock) {
+                if (containedBlock != null && containedBlock.getBlock() instanceof GrassBlock) {
                     return BiomeColors.getGrassColor(lightReader,pos);
                 }
                 return Minecraft.getInstance().getBlockColors().getColor(containedBlock, lightReader, pos, tintIndex);


### PR DESCRIPTION
Within the context of Create's Schematicanon (and presumably any other world-snippet that's used for rendering), especially when combined with CCL, it seems eminently possible that `getMimic` can potentialyl return a null value. You even have a null-check for `mimic` in the `FrameBlockTile`'s NBT writing. [Relevant crash report here](https://gist.github.com/noobanidus/3e8976d9e0793eb56b5bfd395284bb7e).

Obviously it's non-ideal, but Create's method is (as far as I'm aware) a perfectly valid use of a world-snippet for rendering. Likewise, there doesn't appears to be any guarantee that the `mimic` field of a TileEntity *isn't* null.

Adding a null check here prevents the null pointer exception.